### PR TITLE
travis mods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,50 +9,41 @@ python:
 
 stages:
   - lint
-  - build
   - test
 
 env:
-  - ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:$PWD/roles OPENSHIFT_VERSION=latest
-  - ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:$PWD/roles OPENSHIFT_VERSION=v3.9.0
-
-before_install:
-  - sudo apt-get update -qq
-  - sudo sed -i "s/\DOCKER_OPTS=\"/DOCKER_OPTS=\"--insecure-registry=172.30.0.0\/16 /g" /etc/default/docker
-  - sudo cat /etc/default/docker
-  - sudo service docker restart
+  - APB_NAME=mongodb-apb ANSIBLE_ROLES_PATH=$ANSIBLE_ROLES_PATH:$PWD/roles OPENSHIFT_VERSION=v3.9
 
 install:
+  - sudo apt-get update -qq
   - sudo apt-get install git jq
-  - pip install --pre ansible apb yamllint
-  - ansible-galaxy install ansible.kubernetes-modules
-  - git clone https://github.com/ansibleplaybookbundle/ansible-asb-modules.git $PWD/roles/ansibleplaybookbundle.asb-modules
 
 jobs:
   include:
   - stage: lint
     python: '2.7'
     script:
+      - pip install --pre ansible apb yamllint
+      - ansible-galaxy install ansible.kubernetes-modules
+      - git clone https://github.com/ansibleplaybookbundle/ansible-asb-modules.git $PWD/roles/ansibleplaybookbundle.asb-modules
       # Verify all playbooks have valid syntax
       - |
         for PLAYBOOK in playbooks/{provision,deprovision,test}.yml
         do ansible-playbook $PLAYBOOK --syntax-check
         done
-  - stage: lint
-    python: '2.7'
-    script:
       # Verify apb.yml file is valid YAML
       - yamllint apb.yml
 
-# Test Stage
-script:
-  - export APB_NAME=mongodb-apb
-  - apb build
-  - export B64_SPEC=`base64 apb.yml | tr -d '\n'`
-  - export APB_LABEL=`docker inspect --format='{{json .Config.Labels}}' $(docker images -q | head -n 1) | jq '."com.redhat.apb.spec"' | cut -d'"' -f2 | tr -d '\n'`
-  - if [ "$B64_SPEC" != "$APB_LABEL" ]; then { echo "APB Spec Label doesn't match"; exit -1; }; fi;
-  - sudo docker cp $(docker create docker.io/openshift/origin:$OPENSHIFT_VERSION):/bin/oc /usr/local/bin/oc
-  - oc cluster up --version=$OPENSHIFT_VERSION
-  - oc login -u system:admin
-  - oc new-project $APB_NAME
-  - docker run --rm --net=host -v $HOME/.kube:/opt/apb/.kube:z -u $UID $APB_NAME test --extra-vars "travis=true" 
+  - stage: test
+    script:
+      - sudo sed -i "s/\DOCKER_OPTS=\"/DOCKER_OPTS=\"--insecure-registry=172.30.0.0\/16 /g" /etc/default/docker
+      - sudo cat /etc/default/docker
+      - sudo service docker restart
+      - docker build -t $APB_NAME .
+      - export B64_SPEC=`base64 apb.yml | tr -d '\n'`
+      - export APB_LABEL=`docker inspect --format='{{json .Config.Labels}}' $(docker images -q | head -n 1) | jq '."com.redhat.apb.spec"' | cut -d'"' -f2 | tr -d '\n'`
+      - if [ "$B64_SPEC" != "$APB_LABEL" ]; then { echo "APB Spec Label doesn't match, run - apb prepare"; exit -1; }; fi;
+      - sudo docker cp $(docker create docker.io/openshift/origin:$OPENSHIFT_VERSION):/bin/oc /usr/local/bin/oc
+      - oc cluster up --version=$OPENSHIFT_VERSION
+      - oc new-project $APB_NAME
+      - docker run --rm --net=host -v $HOME/.kube:/opt/apb/.kube:z -u $UID $APB_NAME test --extra-vars "travis=true"


### PR DESCRIPTION
 - move away from `apb build` for spec test... we need to be sure whatever Dockerfile spec label is committed is accurate.  using `apb build` would fix whatever issues exist before the test occurs.
 - remove `latest` openshift release env
 - remove `system:admin` login
 - cleanup